### PR TITLE
feat: add type augmentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "figma-await-call",
+  "name": "figma-await-ipc",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "figma-await-call",
+      "name": "figma-await-ipc",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/src/CallSignatures.ts
+++ b/src/CallSignatures.ts
@@ -1,0 +1,4 @@
+/**
+ * Augment this interface with your own call signatures.
+ */
+export interface CallSignatures {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./api";
+export * from "./CallSignatures";
 export * from "./DeferredPromise";


### PR DESCRIPTION
This pull request introduces a type-safe mechanism for defining and managing call signatures in the codebase. The changes enhance type safety for inter-thread communication by leveraging TypeScript's advanced type features. Key updates include the introduction of a new `CallSignatures` interface, modifications to the `call` and `receive` functions, and updates to the `receiversByName` structure.

### Type Safety Enhancements:

* **Introduction of `CallSignatures`:**
  - Added a new `CallSignatures` interface to define call signatures and a utility type `AnyIfEmpty` to handle cases where the interface might be empty. (`src/CallSignatures.ts`, [src/CallSignatures.tsR1-R6](diffhunk://#diff-9bcc83bf83e4cde72a02f25215d5b97476f3a42b2df20693691490dde3198d7dR1-R6))

* **Type-safe `call` Function:**
  - Updated the `call` function to use `CallSignatures` for type-safe parameter and return type inference. The function now ensures that the `name` and `data` parameters align with the defined call signatures. (`src/api.ts`, [src/api.tsL44-R60](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700L44-R60))

* **Type-safe `receive` Function:**
  - Modified the `receive` function to enforce type safety by ensuring that the `name` and `fn` parameters conform to the `CallSignatures` interface. (`src/api.ts`, [src/api.tsL75-R85](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700L75-R85))

### Structural Updates:

* **Enhanced `receiversByName` Type:**
  - Updated the `receiversByName` structure to use the `AnyIfEmpty` utility type for improved type safety, ensuring compatibility with `CallSignatures`. (`src/api.ts`, [src/api.tsL33-R36](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700L33-R36))

* **Export of New Types:**
  - Exported the newly introduced `CallSignatures` type from the `src/index.ts` file to make it available for external usage. (`src/index.ts`, [src/index.tsR2](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2))

### Example Usage

```ts
/* figma-plugin/shared-src/figma-await-ipc.d.ts */

import 'figma-await-ipc';

declare module 'figma-await-ipc' {
  interface CallSignatures {
    showNotification: (message: string) => void;
  }
}
```

```ts
call("showNotification", "My Message") // OK
receive("showNotification", (message) => { figma.notify(message); }) // OK
call("showNotification") // Expected 2 arguments, but got 1.ts(2554)
```